### PR TITLE
Replace deprecated cmake functions

### DIFF
--- a/tools/FindPythonLibsNew.cmake
+++ b/tools/FindPythonLibsNew.cmake
@@ -57,12 +57,12 @@ endif()
 
 # Use the Python interpreter to find the libs.
 if(PythonLibsNew_FIND_REQUIRED)
-    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} REQUIRED)
+    find_package(Python COMPONENTS Interpreter ${PythonLibsNew_FIND_VERSION} REQUIRED)
 else()
-    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION})
+    find_package(Python COMPONENTS Interpreter ${PythonLibsNew_FIND_VERSION})
 endif()
 
-if(NOT PYTHONINTERP_FOUND)
+if(NOT Python_Interpreter_FOUND)
     set(PYTHONLIBS_FOUND FALSE)
     set(PythonLibsNew_FOUND FALSE)
     return()
@@ -74,7 +74,7 @@ endif()
 #
 # The library suffix is from the config var LDVERSION sometimes, otherwise
 # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+execute_process(COMMAND "${Python_EXECUTABLE}" "-c"
     "from distutils import sysconfig as s;import sys;import struct;
 print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
@@ -196,7 +196,7 @@ SET(PYTHON_DEBUG_LIBRARIES "${PYTHON_DEBUG_LIBRARY}")
 
 find_package_message(PYTHON
     "Found PythonLibs: ${PYTHON_LIBRARY}"
-    "${PYTHON_EXECUTABLE}${PYTHON_VERSION}")
+    "${Python_EXECUTABLE}${PYTHON_VERSION}")
 
 set(PYTHONLIBS_FOUND TRUE)
 set(PythonLibsNew_FOUND TRUE)


### PR DESCRIPTION
`find_package(PythonInterp)` is deprecated.
`find_package(Python COMPONENTS Interpreter)` should be used instead.

Upstream-Status: Submitted [https://github.com/pybind/pybind11/pull/2203]